### PR TITLE
[Followup] Point links to use the nteract organization's copy of the commuter demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Example notebooks are from the official nteract repository on [Github](https://g
 
 ## Links
 
-- [Live Demo](https://hydrosquall-nteract-commuter-glitch-demo.glitch.me/view/)
+- [Live Demo](https://nteract-commuter-glitch-demo.glitch.me/view/)
 - [Commuter Source Code](https://github.com/nteract/nteract/tree/master/applications/commuter)
 - [nteract Organization](https://nteract.io)
+- [Demo Source Code](https://github.com/nteract/commuter-on-glitch)


### PR DESCRIPTION
This is a followup to https://github.com/nteract/nteract/pull/3451#issuecomment-430069966.

This change makes it easier for people who see the demo to find out how to check the underlying source code, which is especially relevant if they haven't used Glitch before.

cc @captainsafia 